### PR TITLE
任意のタイミングでもう一度デフォルト設定を行えるように修正。

### DIFF
--- a/autoload/ambiwidth.vim
+++ b/autoload/ambiwidth.vim
@@ -6,7 +6,7 @@ function! ambiwidth#plugin_vimscript_generator() abort
         \ "",
         \ "let g:loaded_ambiwidth = 1",
         \ "",
-        \ "if (&encoding == 'utf-8') && exists('*setcellwidths') && has('vim_starting')",
+        \ "function! ambiwidth#set_ambiwidth() abort",
         \ "\tset ambiwidth=single",
         \ "\tcall setcellwidths([",
         \ ] + s:double_cells_codes(s:default()) + [
@@ -14,6 +14,10 @@ function! ambiwidth#plugin_vimscript_generator() abort
         \ ] + s:double_cells_codes(s:cica()) + [
         \ "\t\t\\ ] : [])",
         \ "\t\t\\ + get(g:, 'ambiwidth_add_list', []))",
+        \ "endfunction",
+        \ "",
+        \ "if (&encoding == 'utf-8') && exists('*setcellwidths') && has('vim_starting')",
+        \ "\tcall ambiwidth#set_ambiwidth()",
         \ "endif",
         \ ]
     call writefile(lines, expand(s:rootdir .. '/plugin/ambiwidth.vim'))

--- a/plugin/ambiwidth.vim
+++ b/plugin/ambiwidth.vim
@@ -1,7 +1,7 @@
 
 let g:loaded_ambiwidth = 1
 
-if (&encoding == 'utf-8') && exists('*setcellwidths') && has('vim_starting')
+function! ambiwidth#set_ambiwidth() abort
 	set ambiwidth=single
 	call setcellwidths([
 		\ [0x2030, 0x203f, 2],
@@ -102,4 +102,8 @@ if (&encoding == 'utf-8') && exists('*setcellwidths') && has('vim_starting')
 		\ [0xff500, 0xffd46, 2],
 		\ ] : [])
 		\ + get(g:, 'ambiwidth_add_list', []))
+endfunction
+
+if (&encoding == 'utf-8') && exists('*setcellwidths') && has('vim_starting')
+	call ambiwidth#set_ambiwidth()
 endif


### PR DESCRIPTION
昨今 CLI アプリで ambiwidth の文字が使われるようになり、 vim-ambiwidth を使用しているとターミナルで予期せぬ折り返しが発生することがあります。

そんな場合に、「ターミナルを使うときだけ一時的に全部半角で表示したい」と思うのですが、現在の vim-ambiwidth は一度 setcellwidth を呼び出し更新すると、元に戻せません。

これを解消するため、現在の setcellwidth を呼び出している箇所を関数として切り出し、任意のタイミングで呼び出せるようにしました。

参考情報: 

- https://x.com/mikoto2000/status/1923712167234371721
- https://x.com/mikoto2000/status/1923711827776839943